### PR TITLE
.click must pass .parentNode x3 to SelectPatient()

### DIFF
--- a/interface/main/finder/patient_select.php
+++ b/interface/main/finder/patient_select.php
@@ -684,7 +684,7 @@ $(document).ready(function(){
     // $("#searchparm").focus();
     $(".oneresult").mouseover(function() { $(this).addClass("highlight"); });
     $(".oneresult").mouseout(function() { $(this).removeClass("highlight"); });
-    $(".oneresult").click(function() { SelectPatient(this); });
+    $(".oneresult").click(function() { SelectPatient(this.parentNode.parentNode.parentNode); });
     // $(".event").dblclick(function() { EditEvent(this); });
     <?php if($print_patients) { ?>
       var win = top.printLogPrint ? top : opener.top;
@@ -706,10 +706,9 @@ else {
     $target = "top";
 }
 ?>
-    objID = eObj.id;
-    var parts = objID.split("~");
+    var tableId = eObj.id;
     <?php if (!$popup) echo "top.restoreSession();\n"; ?>
-    <?php if ($popup) echo "opener."; echo $target; ?>.location.href = '<?php echo $newPage; ?>' + parts[0];
+    <?php if ($popup) echo "opener."; echo $target; ?>.location.href = '<?php echo $newPage; ?>' + tableId;
     <?php if ($popup) echo "window.close();\n"; ?>
     return true;
 }


### PR DESCRIPTION
@samlikins : Please review this fix to interface/main/finder/patient_select.php, which we both worked on, and let me know if I've done it wrong.
If you recall, clicking on the patient's Name or Gender or DOB (but not other TD columns) should browse to the patient's demographics.  Somewhere along the lines, it stopped working.

A snippit of the table structure is:

> ```
>   <table id='2'>
>   <tr>
>       <td class='oneresult srName'>Wise, Janet</td>
>       <td class='oneresult srGender'>Female</td>
>       <td class='oneresult srDOB'>10/04/1946</td>
>       <td class='srAnswer'> .....
> ```

For the clicked object to see the table id, I changed the SelectPatient() call to pass this.parentNode.parentNode.parentNode which seems to work. 

I've tested successfully for PQRS and will test for non-PQRS once I find a  good report to run against it.
