### PR TITLE
Importer deletes users+groups w/ id over 20

### DIFF
--- a/interface/main/PQRS/import_data.php
+++ b/interface/main/PQRS/import_data.php
@@ -55,6 +55,7 @@ sqlStatement($query);
 sqlStatement("TRUNCATE TABLE `insurance_data`;");
 $query = file_get_contents("./SQL/insurance_data.sql", true);
 sqlStatement($query);
+
 sqlStatement("TRUNCATE TABLE `patient_data`;");
 $query = file_get_contents("./SQL/patient_data.sql", true);
 sqlStatement($query);
@@ -67,9 +68,11 @@ sqlStatement("TRUNCATE TABLE `x12_partners`;");
 $query = file_get_contents("./SQL/x12_partners.sql", true);
 sqlStatement($query);
 
+sqlStatement("DELETE FROM `users` WHERE `users`.`id` > '20';");
 $query = file_get_contents("./SQL/users.sql", true);
 sqlStatement($query);
 
+sqlStatement("DELETE FROM `groups` WHERE `groups`.`id` > '20';");
 $query = file_get_contents("./SQL/groups.sql", true);
 sqlStatement($query);
 echo "Database updated!";


### PR DESCRIPTION
When importing provider 837 files, delete any users or groups with an id > 20.  
This allows us to re-run an import with no user/group collisions, but we also keep the low-numbered users that we previously created.
