### PR TITLE
patient_report syntax error

### DIFF
--- a/library/report_database.inc
+++ b/library/report_database.inc
@@ -407,7 +407,7 @@ function collectItemizedPatientsCdrReport($report_id,$itemized_test_id,$pass='al
 	
     if(count($exlPidArr) > 0){
       $exlPids = implode(",", $exlPidArr);
-      $sql_where .= " AND patient_data.pid NOT IN(add_escape_custom($exlPids)) ";
+      $sql_where .= " AND patient_data.pid NOT IN(".add_escape_custom($exlPids).") ";
     }
     array_push($sqlParameters,$pass_sql);
   }


### PR DESCRIPTION
php contained in SQL string.  Messes up listing patients.