### PR TITLE
Rm measure group selection

### DIFF
--- a/interface/reports/clinical_measures.php
+++ b/interface/reports/clinical_measures.php
@@ -501,6 +501,9 @@ function Form_Validate() {
     if(in_array($type_report, array('pqrs', 'pqrs_individual_2015', 'pqrs_groups_2015', 'pqrs_individual_2016', 'pqrs_groups_2016'))) {
 
 //  Nothing.  Do NOTHING!  --leebc
+?>
+		<input type='hidden' id='form_plan_filter' name='form_plan_filter' value=''>
+<?php
 
  } elseif(in_array($type_report, array('amc', 'amc_2011', 'amc_2014_stage1', 'amc_2014_stage2'))) { ?>
                   <input type='hidden' id='form_plan_filter' name='form_plan_filter' value=''>


### PR DESCRIPTION
* Renamed "Measure Set'" to "Report Type"
* Altered value descriptors from
  *  "All 2016 PQRS Individual Measures" and 
  *  "All 2016 PQRS Group Measures" TO
  *  "Individual Measures" and
  *  "Measure Groups"
* Removed "Measure Group Selection" pull down and replaced with hidden value that is passed downstream in the report engine
* Commented out code that generates the buttons "Generate PQRS report (SimpleXML) 2015" and "Stub for additional xml format submissions" so that these could be used if this is where we ultimately decide to put the XML generate button.  (This is the weird looking change at the end of the diff.