### PR TITLE
Added site name to debug message about measure run

### DIFF
--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -747,7 +747,7 @@ if (strpos($type, 'pqrs_individual') !== false ) {
       require_once( dirname(__FILE__)."/classes/rulesets/ReportManager.php");
       $manager = new ReportManager();
       if ($rowRule['amc_flag']|| $rowRule['pqrs_individual_2016_flag'] || $rowRule['pqrs_individual_2015_flag'] || $rowRule['pqrs_groups_2016_flag']|| $rowRule['pqrs_groups_2015_flag']) {
-	error_log("*DEBUG*: clinical_rules: About to runReport for ".$rowRule['id']);
+	error_log("*DEBUG*: clinical_rules: Site: ".$_SESSION['site_id']."  About to runReport for ".$rowRule['id']);
         // Send array of dates ('dateBegin' and 'dateTarget')
         $tempResults = $manager->runReport( $rowRule, $patientData, $dateArray, $options );
       }


### PR DESCRIPTION
	modified:   library/clinical_rules.php

This modifies clinical_rules.php's logging so the site name is included.   Right now, if I'm watching the logs, I only see that a measure is being fired.  If multiple sites are running reports at the same time, i can't tell which site the log message is from.