### PR TITLE
Changed p.providerID to fe.provider_id

### DIFF
--- a/library/classes/rulesets/PQRS/groups/common/CABGcommon.php
+++ b/library/classes/rulesets/PQRS/groups/common/CABGcommon.php
@@ -16,7 +16,7 @@ $query =
 " JOIN form_encounter AS fe ON (b1.encounter = fe.encounter)".
 " JOIN patient_data AS p ON (p.pid = b1.pid)".
 " WHERE b1.pid = ? ".
-" AND p.providerID = '".$this->_reportOptions['provider']."'".
+" AND fe.provider_id = '".$this->_reportOptions['provider']."'".
 " AND fe.date BETWEEN '".$beginDate."' AND '".$endDate."' ".
 " AND TIMESTAMPDIFF(YEAR,p.DOB,fe.date) >= '18' ".
 " AND (b1.code = codelist_a.code AND codelist_a.type = 'pqrs_CABG_a');";

--- a/library/classes/rulesets/PQRS/groups/common/Cataractscommon.php
+++ b/library/classes/rulesets/PQRS/groups/common/Cataractscommon.php
@@ -16,7 +16,7 @@ $query =
 " JOIN form_encounter AS fe ON (b1.encounter = fe.encounter)".
 " JOIN patient_data AS p ON (b1.pid = p.pid)". 
 " WHERE b1.pid = ? ".
-" AND p.providerID = '".$this->_reportOptions['provider']."'".  
+" AND fe.provider_id = '".$this->_reportOptions['provider']."'".  
 " AND fe.date BETWEEN '".$beginDate."' AND DATE_SUB('".$endDate."', INTERVAL 3 MONTH) ".
 " AND TIMESTAMPDIFF(YEAR,p.DOB,fe.date) >= '18'  ". 
 " AND (b1.code = codelist_a.code AND codelist_a.type = 'pqrs_cataracts_a') ".

--- a/library/classes/rulesets/PQRS/groups/common/OPEIRcommon.php
+++ b/library/classes/rulesets/PQRS/groups/common/OPEIRcommon.php
@@ -16,7 +16,7 @@ $query =
 " JOIN form_encounter AS fe ON (b1.encounter = fe.encounter)".
 " JOIN patient_data AS p ON (b1.pid = p.pid)". 
 " WHERE b1.pid = ? ". 
-" AND p.providerID = '".$this->_reportOptions['provider']."'".
+" AND fe.provider_id = '".$this->_reportOptions['provider']."'".
 " AND fe.date BETWEEN '".$beginDate."' AND '".$endDate."' ". 
 " AND (b1.code = codelist_a.code AND codelist_a.type = 'pqrs_OPEIR_a');";
 ?>

--- a/library/classes/rulesets/PQRS/groups/common/Surgerycommon.php
+++ b/library/classes/rulesets/PQRS/groups/common/Surgerycommon.php
@@ -16,7 +16,7 @@ $query =
 " JOIN form_encounter AS fe ON (b1.encounter = fe.encounter)".
 " JOIN patient_data AS p ON (b1.pid = p.pid)". 
 " WHERE b1.pid = ? ".
-" AND p.providerID = '".$this->_reportOptions['provider']."'".  
+" AND fe.provider_id = '".$this->_reportOptions['provider']."'".  
 " AND fe.date BETWEEN '".$beginDate."' AND '".$endDate."' ".
 " AND TIMESTAMPDIFF(YEAR,p.DOB,fe.date) >= '18' ".
 " AND (b1.code = codelist_a.code AND codelist_a.type = 'pqrs_surgery_a');";

--- a/library/classes/rulesets/PQRS/groups/common/TKRcommon.php
+++ b/library/classes/rulesets/PQRS/groups/common/TKRcommon.php
@@ -16,7 +16,7 @@ $query =
 " INNER JOIN pqrs_group AS codelist_a ON (b1.code = codelist_a.code)".
 " JOIN patient_data AS p ON (b1.pid = p.pid)". 
 " WHERE b1.pid = ? ".
-" AND p.providerID = '".$this->_reportOptions['provider']."'".  
+" AND fe.provider_id = '".$this->_reportOptions['provider']."'".  
 " AND (b1.code = codelist_a.code AND codelist_a.type = 'pqrs_TKR_a') ".
 " AND fe.date BETWEEN '".$beginDate."' AND '".$endDate."' ".
 " AND TIMESTAMPDIFF(YEAR,p.DOB,fe.date) >= '18' ;";


### PR DESCRIPTION
Use the form_encounter's provider (the provider performed the procedure) instead of the patient's primary provider (which we're truncating to 0 anyway).

	modified:   library/classes/rulesets/PQRS/groups/common/CABGcommon.php
	modified:   library/classes/rulesets/PQRS/groups/common/Cataractscommon.php
	modified:   library/classes/rulesets/PQRS/groups/common/OPEIRcommon.php
	modified:   library/classes/rulesets/PQRS/groups/common/Surgerycommon.php
	modified:   library/classes/rulesets/PQRS/groups/common/TKRcommon.php