### PR TITLE
Functionality to add report renaming

### DIFF
--- a/interface/reports/clinical_measures.php
+++ b/interface/reports/clinical_measures.php
@@ -44,7 +44,7 @@ $back_link = existsDefault($_GET, 'back');
 // If showing an old report, then collect information
 if(!empty($report_id)) {
   $report_view = collectReportDatabase($report_id);
-  
+
   //error_log("report_view is ".print_r($report_view,TRUE),0);
 
   $date_report = $report_view['date_report'];
@@ -427,7 +427,10 @@ function Form_Validate() {
     	} else {
 		$report_title="";
     	}
-	echo ("Report Title:  $report_title \n"); ?>
+	if ($report_title != "" ) {
+		echo ("Report Title:  $report_title \n");
+	}  ?>
+
                         </span>
                     </div>
 		  </td>
@@ -605,7 +608,7 @@ function Form_Validate() {
 
           if(isset($row['is_main'])) {
               $failed_items = $row['pass_filter'] - $row['pass_target'] - $row['excluded'];
-  
+
           } 
 
           if(isset($row['itemized_test_id']) && ($failed_items > 0) ) {

--- a/interface/reports/report_results.php
+++ b/interface/reports/report_results.php
@@ -17,6 +17,7 @@
  * along with this program. If not, see <http://opensource.org/licenses/gpl-license.php>;.
  *
  * @package OpenEMR
+ * @author  Bryan Lee <bryan@suncoastconnection.com>
  * @author  Brady Miller <brady@sparmy.com>
  * @link    http://www.open-emr.org
  */
@@ -166,6 +167,12 @@ require_once "$srcdir/report_database.inc";
 <table>
 
  <thead>
+  <th align='left'>
+   <?php echo htmlspecialchars( xl('Delete'), ENT_NOQUOTES); ?>
+  </th>
+  <th align='left'>
+   <?php echo htmlspecialchars( xl('Rename'), ENT_NOQUOTES); ?>
+  </th>
   <th align='center'>
    <?php echo htmlspecialchars( xl('Title'), ENT_NOQUOTES); ?>
   </th>
@@ -186,57 +193,7 @@ require_once "$srcdir/report_database.inc";
  while ($row = sqlFetchArray($res)) {
 
   // Figure out the title and link
-  if ($row['type'] == "cqm") {
-    if (!$GLOBALS['enable_cqm']) continue;
-    $type_title = xl('Clinical Quality Measures (CQM)');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "cqm_2011") {
-    if (!$GLOBALS['enable_cqm']) continue;
-    $type_title = xl('2011 Clinical Quality Measures (CQM)');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "cqm_2014") {
-    if (!$GLOBALS['enable_cqm']) continue;
-    $type_title = xl('2014 Clinical Quality Measures (CQM)');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "amc") {
-    if (!$GLOBALS['enable_amc']) continue;
-    $type_title = xl('Automated Measure Calculations (AMC)');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "amc_2011") {
-    if (!$GLOBALS['enable_amc']) continue;
-    $type_title = xl('2011 Automated Measure Calculations (AMC)');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "amc_2014") {
-    if (!$GLOBALS['enable_amc']) continue;
-    $type_title = xl('2014 Automated Measure Calculations (AMC)');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "amc_2014_stage1") {
-    if (!$GLOBALS['enable_amc']) continue;
-    $type_title = xl('2014 Automated Measure Calculations (AMC) Stage I');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "amc_2014_stage2") {
-    if (!$GLOBALS['enable_amc']) continue;
-    $type_title = xl('2014 Automated Measure Calculations (AMC) Stage II');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "pqrs_individual_2015") {
-    if (!$GLOBALS['enable_pqrs']) continue;
-    $type_title = xl('2015 PQRS Individual Measures');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "pqrs_groups_2015") {
-    if (!$GLOBALS['enable_pqrs']) continue;
-    $type_title = xl('2015 PQRS Group Measures');
-    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
-  }
-  else if ($row['type'] == "pqrs_individual_2016") {
+  if ($row['type'] == "pqrs_individual_2016") {
     if (!$GLOBALS['enable_pqrs']) continue;
     $type_title = xl('2016 PQRS Individual Measures');
     $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
@@ -246,7 +203,16 @@ require_once "$srcdir/report_database.inc";
     $type_title = xl('2016 PQRS Group Measures');
     $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
   }
-
+  else if ($row['type'] == "mips_2017" ) {
+    if (!$GLOBALS['enable_pqrs']) continue;
+    $type_title = xl('2017 MIPS Measures');
+    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
+  }
+  else if ($row['type'] == "mips" ) {
+    if (!$GLOBALS['enable_pqrs']) continue;
+    $type_title = xl('MIPS Measures');
+    $link="clinical_measures.php?report_id=" . attr($row["report_id"]) . "&back=list";
+  }
   else if ($row['type'] == "process_reminders") {
     if (!$GLOBALS['enable_cdr']) continue;
     $type_title = xl('Processing Patient Reminders');
@@ -277,8 +243,26 @@ require_once "$srcdir/report_database.inc";
     $type_title = xl('Unknown') . "-" . $row['type'];
     $link="";
   }
+
+    // Reset the title based on a having a title in the row
+//error_log("DEBUG: title is [".$row['title']."]",0);
+  if ( $row['title'] != "0" ) {
+    $type_title = xl($row['title']);
+  }
+
 ?>
  <tr>
+      <td>
+         <a id='delete_button' href='#' class='css_button_small'
+           onclick='deleteReport(<?php echo htmlspecialchars( $row["report_id"] ) ?>)' >
+         <span>Delete</span></a>
+      </td>
+      <td>
+         <a id='rename_button' href='#' class='css_button_small'
+           onclick='renameReport(<?php echo htmlspecialchars( $row["report_id"] ) ?>)' >
+         <span>Rename</span></a>
+      </td>
+
     <?php if ($row["progress"] == "complete") { ?>
       <td align='center'><a href='<?php echo $link; ?>' onclick='top.restoreSession()'><?php echo text($type_title); ?></a></td>
     <?php } else { ?>
@@ -312,6 +296,56 @@ require_once "$srcdir/report_database.inc";
 <script language="Javascript">
  Calendar.setup({inputField:"form_begin_date", ifFormat:"%Y-%m-%d %H:%M:%S", button:"img_begin_date", showsTime:'true'});
  Calendar.setup({inputField:"form_end_date", ifFormat:"%Y-%m-%d %H:%M:%S", button:"img_end_date", showsTime:'true'});
+</script>
+
+
+<!--  Stuff for deleting and renaming reports -->
+<script type='text/javascript'>
+function manageReport(report_id,action,newname){
+	console.log('manageReport:  report_id= ' + report_id + '  action= ' + action + ' newname= ' +newname);
+        $.ajax({
+                type: 'POST',
+                url: '<?php echo $GLOBALS['webroot']; ?>/library/classes/rulesets/PQRS/PQRSReportManager.php',
+                dataType: 'text',
+                data: {
+                        report_id: report_id,
+                        action: action,
+                        report_new_name: newname,
+                },
+                success: function(data, status, xHR) {
+                        if(data == 'SUCCESS') {
+                                console.log('Update succeeded.');
+                        } else {
+                                console.log('Update failed: '+ data);
+                        }
+                },
+                error: function(xHR, status, error) {
+                        console.log('Status: ' + status + ', Error: ' + error);
+                }
+        });
+}
+
+function deleteReport(report_id){
+    var answer = confirm('Are you sure you want to delete this report?');
+    if (answer == true) {
+//        console.log('Delete Report -- report_id: ' + report_id );
+	manageReport(report_id,'DELETE','deleted');
+    }
+}
+
+function renameReport(report_id){
+    var newname = prompt('New name for this report?');
+    console.log('Rename Report -- prompt got: ' + newname);
+//    if (newname == "")  {
+//        confirm('You didn\'t supply a new name.');
+//    } else {
+        console.log('Rename Report -- report_id: ' + report_id + ', New Name: ' + newname);
+	manageReport(report_id,'RENAME',newname);
+//    }
+
+top.restoreSession();  $("#theform").submit();
+}
+
 </script>
 
 </html>

--- a/library/classes/rulesets/PQRS/PQRSReportManager.php
+++ b/library/classes/rulesets/PQRS/PQRSReportManager.php
@@ -1,0 +1,48 @@
+<?php
+ /*
+ * Copyright (C) 2017      Suncoast Connection
+ *
+ * @package OpenEMR
+ * @author  Suncoast Connection
+ * @author  Bryan Lee
+ * @link    http://suncoastconnection.com
+*/
+
+//require_once(dirname(__FILE__) . "/jsonwrapper/jsonwrapper.php");
+include_once(__DIR__.'/../../../../interface/globals.php');
+include_once(__DIR__.'/../../../../library/sql.inc');
+
+
+error_log("DEBUG PQRSReportManager.php -- started");
+
+//  Begin Main
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+	$myaction=$_POST['action'];
+	$myreport_id = $_POST['report_id'];
+	$myreport_new_name = $_POST['report_new_name'];
+
+error_log("DEBUG PQRSReportManager.php -- POSTed us with action=".$myaction."  report_id=".$myreport_id."  report_new_name = ".$report_new_name.".");
+
+	if ( $myaction=='DELETE' && $myreport_id != '' ) {
+			sqlStatement("DELETE FROM `report_results` WHERE `report_id` = ".$myreport_id.";");
+			sqlStatement("DELETE FROM `report_itemized` WHERE `report_id` = ".$myreport_id.";");
+			echo ("Deleted 'report_results' and 'report_itemized' that match id ".$myreport_id);
+	}
+
+	if ( $myaction=='RENAME' && $myreport_id != '' && $myreport_new_name != '' ) {
+		//$query = "REPLACE INTO report_results (report_id, field_id, field_value) VALUES (".$myreport_id.", 'title', '".$myreport_new_name."')  WHERE report_id = '".$myreport_id."' AND field_id = 'title';";
+		$query = "INSERT INTO report_results (report_id, field_id, field_value) VALUES(".$myreport_id.", 'title', '".$myreport_new_name."') ON DUPLICATE KEY UPDATE field_value='".$myreport_new_name."';";
+		error_log("DEBUG PQRSReportManager.php -- query = ".$query);
+		//echo ("query $query");
+		sqlStatement($query);
+	}
+
+	if ( $myaction=='DELETEALL') {
+		sqlStatement("TRUNCATE TABLE `report_results`;");
+		sqlStatement("TRUNCATE TABLE `report_itemized`;");
+		echo "Table 'reports_results' truncated and 'report_itemized'.   Old reports deleted.";
+	}
+	echo 'SUCCESS';
+}
+
+?>

--- a/library/report_database.inc
+++ b/library/report_database.inc
@@ -61,7 +61,8 @@ function listingReportDatabase($start_date='',$end_date='') {
                            MAX(if( `field_id` = 'progress', `field_value`, 0 )) as `progress`,
                            MAX(if( `field_id` = 'total_items', `field_value`, 0 )) as `total_items`,
                            MAX(if( `field_id` = 'progress_items', `field_value`, 0 )) as `progress_items`,
-                           MAX(if( `field_id` = 'type', `field_value`, 0 )) as `type`
+                           MAX(if( `field_id` = 'type', `field_value`, 0 )) as `type`,
+                           MAX(if( `field_id` = 'title', `field_value`, 0 )) as `title`
                            FROM `report_results`
                            GROUP BY `report_id`
                          ) AS pt


### PR DESCRIPTION
WORKS!   Intermittently.  I think there's something flaky about the AJAX request or caching.

Requires code review.

modified:   interface/reports/clinical_measures.php
modified:   interface/reports/report_results.php
modified:   library/report_database.inc
new file:   library/classes/rulesets/PQRS/PQRSReportManager.php

* Modified library/report_database.inc to return the 'title' when report is collected.
* Modified clinical_measures.php to only display title if there is one
* Modified report_results.php
	* Removed old AMC, CQM and 2016 PQRS report title references
        * Added buttons to delete and rename
	* Added javascript functions to prompt to delete an rename
	* Added javascript function to make an AJAX call to PQRSReportManager.php
* Created PQRSReportManager.php which provides the backend to make queries to modify reports