### PR TITLE
Measure 47 odd results fix

### DIFF
--- a/library/classes/rulesets/PQRS/reports/PQRS_0047/Numerator.php
+++ b/library/classes/rulesets/PQRS/reports/PQRS_0047/Numerator.php
@@ -32,7 +32,7 @@ $query =
 " JOIN form_encounter AS fe ON (b1.encounter = fe.encounter)".
 " WHERE b1.pid = ? ".
 " AND fe.date BETWEEN '".$beginDate."' AND '".$endDate."' ".
-" AND ( b1.code = '1123F' AND b1.modifier ='') OR( b1.code = '1124F' ); ";
+" AND (( b1.code = '1123F' AND b1.modifier ='') OR( b1.code = '1124F' )); ";
 //1123F-8P hard fail
 $result = sqlFetchArray(sqlStatementNoLog($query, array($patient->id))); 
 


### PR DESCRIPTION
unnested parens giving bad results.  Still cannot confirm why it matters
at all, but this verifies the fix.

Manually updated due to reporting emergency.  Unsure if prod permissions would allow me to pull.