### PR TITLE
php notice calendar_timezone

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -533,7 +533,7 @@ if ($fake_register_globals) {
 }
 
 
-if ($GLOBALS['calendar_timezone'] !== '') {
+if (!empty($GLOBALS['calendar_timezone']) {
   // getting selected option (in globals)
   $timezone = $GLOBALS['calendar_timezone'];
   if (strpos($timezone, '!') !== false) {


### PR DESCRIPTION
need to use !empty
I think this is the proper way to resolve this.  You will get the notice if the variable is uninitialized, unless you use empty().
-Someone check this plz.