### PR TITLE
Update gen_x12_837.inc.php

### DIFF
--- a/library/gen_x12_837.inc.php
+++ b/library/gen_x12_837.inc.php
@@ -151,12 +151,13 @@ $CMS_5010 = true;
     "*" .
     "*46";
   }
-
+  if ($claim->payerName() == 'FLORIDA BLUE'){
+	  $out  .=  "*HC279";}else{
   if (trim($claim->x12gsreceiverid()) == '470819582') { // if ECLAIMS EDI
     $out  .=  "*" . $claim->clearingHouseETIN();
   } else {
     $out  .=  "*" . $claim->billingFacilityETIN();
-  }
+	  }}
     $out .= "~\n";
 
   ++$edicount;
@@ -192,6 +193,11 @@ $CMS_5010 = true;
 
   $HLBillingPayToProvider = $HLcount++;
 
+  // Situational PRV segment (for provider taxonomy code) situational inclusion for Beacon.
+  if ($claim->payerID()=='43324' || $claim->payerID()=='87357') {
+ ++$edicount;
+    $out .= "PRV*BI*PXC*251S00000X~\n";
+    }else{
   //Need Facility Taxonomy in UI.  Facility taxonomy should belong to business, not the provider.
   //Situational PRV segment for provider taxonomy code for Medicaid.
     if ($claim->claimType() == 'MC') {
@@ -199,7 +205,7 @@ $CMS_5010 = true;
         $out .= "PRV*BI*ZZ" .
         "*" . $claim->providerTaxonomy() .
         "~\n";
-    }
+    }}
 
   // Situational CUR segment (foreign currency information) omitted here.
 
@@ -762,8 +768,8 @@ $CMS_5010 = true;
         ++$edicount;
         $out .= "PRV" .
         "*PE" . // Performing provider
+        //The next line needs an insurance level tweak.  Company may require PXC or ZZ due to inconsistency.
         "*" .($claim->claimType() != 'MC' ? "PXC" : "ZZ") .
-        "*PXC" .
         "*" . $claim->providerTaxonomy() .
         "~\n";
     }


### PR DESCRIPTION
Wrote in some exceptions for some Medicaid payers.
Also Loop 2310B was printing ZZ*PCX or PCX*PCX instead of just of just *PCX or *ZZ.